### PR TITLE
Create .nomedia file in projects directory if not exists

### DIFF
--- a/common/src/main/java/com/itsaky/androidide/managers/ToolsManager.java
+++ b/common/src/main/java/com/itsaky/androidide/managers/ToolsManager.java
@@ -53,6 +53,7 @@ public class ToolsManager {
 
     CompletableFuture.runAsync(
             () -> {
+              writeNoMediaFile();
               copyBusyboxIfNeeded();
               extractLogsenderIfNeeded();
               extractAapt2();
@@ -73,7 +74,20 @@ public class ToolsManager {
               }
             });
   }
-
+  
+  private static void writeNoMediaFile() {
+    final var noMedia = new File(BaseApplication.getBaseInstance().getProjectsDir(), ".nomedia");
+    if (!noMedia.exists()) {
+      try {
+        if (!noMedia.createNewFile()) {
+          LOG.error("Failed to create .nomedia file in projects directory");
+        }
+      } catch (IOException e) {
+        LOG.error("Failed to create .nomedia file in projects directory");
+      }
+    }
+  }
+  
   private static void extractAndroidJar() {
     if (!Environment.ANDROID_JAR.exists()) {
       ResourceUtils.copyFileFromAssets(


### PR DESCRIPTION
As the AndroidIDE projects directory is not expected to store any multimedia files, a `.nomedia` file should be created so that it is not scanned for media files. This PR modifies the `ToolsManager` class to create that file.