### PR TITLE
Dismissing windows whenever IDEEditor loses focus

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/EditorActivity.java
+++ b/app/src/main/java/com/itsaky/androidide/EditorActivity.java
@@ -521,16 +521,7 @@ public class EditorActivity extends IDEActivity
   }
 
   @Override
-  public void onTabUnselected(@NonNull TabLayout.Tab tab) {
-    final var position = tab.getPosition();
-    final var editorView = getEditorAtIndex(position);
-    if (editorView != null) {
-      final var editor = editorView.getEditor();
-      if (editor != null) {
-        editor.ensureWindowsDismissed();
-      }
-    }
-  }
+  public void onTabUnselected(@NonNull TabLayout.Tab tab) {}
 
   @Override
   public void onTabReselected(@NonNull TabLayout.Tab tab) {

--- a/app/src/main/java/com/itsaky/androidide/views/editor/IDEEditor.java
+++ b/app/src/main/java/com/itsaky/androidide/views/editor/IDEEditor.java
@@ -22,10 +22,12 @@ import static com.itsaky.androidide.models.prefs.EditorPreferencesKt.getVisibleP
 import android.app.Dialog;
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.graphics.Rect;
 import android.util.AttributeSet;
 import android.view.inputmethod.EditorInfo;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -664,6 +666,14 @@ public class IDEEditor extends CodeEditor implements com.itsaky.androidide.edito
         }));
   }
 
+  @Override
+  protected void onFocusChanged(final boolean gainFocus, final int direction, @Nullable final Rect previouslyFocusedRect) {
+    super.onFocusChanged(gainFocus, direction, previouslyFocusedRect);
+    if (!gainFocus) {
+      ensureWindowsDismissed();
+    }
+  }
+  
   /** Ensures that all the windows are dismissed. */
   @Override
   public void ensureWindowsDismissed() {


### PR DESCRIPTION
Fixes #490 
Whenever `IDEEditor` loses its focus, all the windows associated with it will be dismissed automatically. Earlier it has to be done manually by explicitly calling `ensureWindowsDismissed()` from outside.