### PR TITLE
Fixed: No color set for verbose logs

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/syntax/colorschemes/SchemeAndroidIDE.java
+++ b/app/src/main/java/com/itsaky/androidide/syntax/colorschemes/SchemeAndroidIDE.java
@@ -182,6 +182,7 @@ public class SchemeAndroidIDE extends EditorColorScheme {
     setColor(LOG_TEXT_WARNING, 0xffFFEB3B);
     setColor(LOG_TEXT_INFO, 0xff4CAF50);
     setColor(LOG_TEXT_DEBUG, 0xfff5f5f5);
+    setColor(LOG_TEXT_VERBOSE, 0xff4fc3f7);
     setColor(LOG_PRIORITY_FG_ERROR, 0xff000000);
     setColor(LOG_PRIORITY_FG_WARNING, 0xff000000);
     setColor(LOG_PRIORITY_FG_INFO, 0xffffffff);


### PR DESCRIPTION
There is no color set for the verbose log output. in `SchemeAndroidIDE` This PR fixes this issue.

_**See line 1 below**_
<img src="https://user-images.githubusercontent.com/102804639/194707189-7585c42d-6d64-4726-87ce-f88e8a59aceb.png" width="250"/>
