### PR TITLE
Translate to UTF-8, update subproject/tooling-api-model/build.gradle,…

### DIFF
--- a/docs/editor/color_schemes.md
+++ b/docs/editor/color_schemes.md
@@ -6,7 +6,7 @@ Custom color schemes are currently used only for languages that use [`tree-sitte
 
 ## File structure
 
-The color schemes stored in the schemes directory must have the following file structure : 
+The color schemes store in the schemes directory must have the following file structure : 
 
 ```
 $HOME/.androidide/ui/editor/schemes
@@ -14,7 +14,7 @@ $HOME/.androidide/ui/editor/schemes
     └── scheme.prop
 ```
 
-Schemes are defined in a directory whose name is same as the id of the scheme.
+Schemes are defined by in a directory whose name is same as the id of the scheme.
 For example, the `default` color scheme has the following directory structure :
 
 ```
@@ -24,26 +24,10 @@ $HOME/.androidide/ui/editor/schemes
     └── scheme.prop
 ```
 
-### Dark variants
-
-Dark variant of a color scheme can be defined by simply creating another color
-scheme with its id suffixed with `-dark`. For example :
-
-```
-$HOME/.androidide/ui/editor/schemes
-├── default  <-- 'default' color scheme
-|   ├── ...
-|   └── scheme.prop
-|
-└── default-dark  <-- Dark variant of 'default' color scheme
-    ├── ...
-    └── scheme.prop
-```
-
 ## Scheme props
 
 The `scheme.prop` file contains basic information about the color scheme such as the scheme name,
-version, etc. This is the file that is first read by the IDE to get
+version, supported languages, etc. This is the file that is first read by the IDE get
 information about the color scheme. The supported properties are :
 
 ```properties
@@ -64,11 +48,6 @@ scheme.isDark=<true|false>
 # This is the file which defines the color scheme
 scheme.file=default.json
 ```
-
-- `scheme.name` - The name of the color scheme. This is used in the color scheme selector in IDE preferences.
-- `scheme.version` - The color scheme version. This is primarily used by the IDE's `ToolsManager` to check if the color schemes that are bundled with the IDE have been updated or not.
-- `scheme.isDark` - Flag for light and dark color schemes.
-- `scheme.file` - The JSON file which defines the color schemes.
 
 ## Color scheme definition
 
@@ -108,7 +87,7 @@ For example :
   // "key": "#hex color code"
 
   "definitions": {
-    // we define 'my_color' here
+    // we define the 'my_color' here
     "my_color": "#6f5a4a",
     ...
   },
@@ -117,21 +96,9 @@ For example :
     // then reference 'my_color' here
     "bg": "@my_color",
 
-    // or here
-    "line.bg": "@my_color",
-    ...
+    // as many times as we want!
+    "line.bg": "@my_color"
   },
-
-  "languages" : [
-    {
-      ...
-      "styles" : {
-        // as many times as we want!
-        "comment": "@my_color",
-      }
-      ...
-    }
-  ]
 }
 ```
 
@@ -176,7 +143,7 @@ The keys for the editor colors can be found
 ### Languages array
 
 The `languages` JSON array contains the color schemes for the supported languages.
-Similar to the [`editor`](#editor-object) object, the _elements_ of the `languages` array
+Similar to the [`editor`](#editor-object) object, the elements of the `languages` array
 can be a JSON object or a string value (reference to other JSON files). If the element in
 the array is a reference to a JSON file, then that JSON file must have a JSON object as its
 root element. Either way, the JSON object defines the tree-sitter metadata and styles for
@@ -217,7 +184,7 @@ specific language types. The syntax for a language object is as follows :
   "local.definitions.values": [ "definition.val", ... ],
   "local.references": [ "reference", ... ],
   "styles": {
-    "<capture>": {  // <capture> is the tree-sitter query capture name
+    "<capture-name>": {
       "bg": "#......",
       "fg": "@...",
       "bold": <true|false>,
@@ -228,6 +195,8 @@ specific language types. The syntax for a language object is as follows :
 }
 ```
 
+The following table briefly explains the elements in the language object:
+
 > Note
 >
 > - `Query` - refers to tree-sitter query.
@@ -235,19 +204,20 @@ specific language types. The syntax for a language object is as follows :
 >
 > Read the [tree-sitter documentation](https://tree-sitter.github.io/tree-sitter/syntax-highlighting#queries) for more details.
 
-- `types`                               - The type of files (file extensions) to which this color scheme can be applied. This entry is an array of string. This is helpful for languages that can have multiple file extensions. For example, a C++ source file can have `h`, `cc` or `cpp` file extension.
-
-- `local.scopes`                        - Capture names for syntax nodes that introduce a new local variable scope.
-- `local.scopes.members`                - Capture names for syntax nodes that introde a new scope for member definitions (for example, scope for fields in a class).
-- `local.definition`                    - Capture names for variable declaration nodes. For example, the `identifier` in a Java variable declaration.
-- `local.definition.values`             - Capture names for the value of the local variable declaration, if any. For example, the initializer in a Java variable declaration.
-- `local.references`                    - Capture names for syntax nodes that are references to a local variable.
-- `styles`                              - JSON object that defines the styles for the query captures. Key for each entry in this object is a tree-sitter query capture name. The value of each entry can be a string with a HEX color code (or color reference) or it can be a JSON object which defines multiple properties for rendering the text for the captured node. See example below for more information.
-- `styles.<capture>.bg`            - The background color for the node.
-- `styles.<capture>.fg`            - The foreground color for the node.
-- `styles.<capture>.bold`          - Whether the node text must be rendered in bold letters.
-- `styles.<capture>.italic`        - Whether the node text must be rendered in italic letters.
-- `styles.<capture>.strikethrough` - Whether the node text must have strikethrough.
+| Element                               | Description                                                                                                                                                                                                                                                                                                                                                                 |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `types`                               | The type of files (file extensions) to which this color scheme can be applied. This entry is an array of string. This is helpful for languages that can have multiple file extensions. For example, a C++ source file can have `h`, `cc` or `cpp` file extension.                                                                                                           |
+| `local.scopes`                        | Capture names for syntax nodes that introduce a new local variable scope.                                                                                                                                                                                                                                                                                                   |
+| `local.scopes.members`                | Capture names for syntax nodes that introde a new scope for member definitions (for example, scope for fields in a class).                                                                                                                                                                                                                                                  |
+| `local.definition`                    | Capture names for variable declaration nodes. For example, the `identifier` in a Java variable declaration.                                                                                                                                                                                                                                                                 |
+| `local.definition.values`             | Capture names for the value of the local variable declaration, if any. For example, the initializer in a Java variable declaration.                                                                                                                                                                                                                                         |
+| `local.references`                    | Capture names for syntax nodes that are references to a local variable.                                                                                                                                                                                                                                                                                                     |
+| `styles`                              | JSON object that defines the styles for the query captures. Key for each entry in this object is a tree-sitter query capture name. The value of each entry can be a string with a HEX color code (or color reference) or it can be a JSON object which defines multiple properties for highlighting the text for the captured node. See example below for more information. |
+| `styles.<capture-name>.bg`            | The background color for the node.                                                                                                                                                                                                                                                                                                                                          |
+| `styles.<capture-name>.fg`            | The foreground color for the node.                                                                                                                                                                                                                                                                                                                                          |
+| `styles.<capture-name>.bold`          | Whether the node text must be rendered in bold letters.                                                                                                                                                                                                                                                                                                                     |
+| `styles.<capture-name>.italic`        | Whether the node text must be rendered in italic letters.                                                                                                                                                                                                                                                                                                                   |
+| `styles.<capture-name>.strikethrough` | Whether the node text must have strikethrough.                                                                                                                                                                                                                                                                                                                            |
 
 
 The JSON object below is a part of the Java language definition in the `default` color scheme. You can refer it for a more practical example.

--- a/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/JavaCompilerProvider.java
+++ b/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/JavaCompilerProvider.java
@@ -64,7 +64,7 @@ public class JavaCompilerProvider {
   // TODO This currently destroys all the compiler instances
   //  We must have a method to destroy only the required instance in
   //  JavaLanguageServer.handleFailure(LSPFailure)
-  public synchronized void destory() {
+  public synchronized void destroy() {
     for (final JavaCompilerService compiler : mCompilers.values()) {
       compiler.destroy();
     }

--- a/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/JavaLanguageServer.java
+++ b/lsp/java/src/main/java/com/itsaky/androidide/lsp/java/JavaLanguageServer.java
@@ -113,7 +113,7 @@ public class JavaLanguageServer implements ILanguageServer {
 
   @Override
   public void shutdown() {
-    JavaCompilerProvider.getInstance().destory();
+    JavaCompilerProvider.getInstance().destroy();
     SourceFileManager.clearCache();
     CacheFSInfoSingleton.INSTANCE.clearCache();
     CachingJarFileSystemProvider.INSTANCE.clearCache();
@@ -157,7 +157,7 @@ public class JavaLanguageServer implements ILanguageServer {
     CachingJarFileSystemProvider.INSTANCE.clearCachesForPaths(path -> path.endsWith("/R.jar"));
 
     // Clear cached module-specific compilers
-    JavaCompilerProvider.getInstance().destory();
+    JavaCompilerProvider.getInstance().destroy();
 
     // Cache classpath locations
     for (final Project subModule : project.getSubModules()) {
@@ -260,7 +260,7 @@ public class JavaLanguageServer implements ILanguageServer {
           return true;
         }
 
-        JavaCompilerProvider.getInstance().destory();
+        JavaCompilerProvider.getInstance().destroy();
         return true;
     }
 

--- a/lsp/java/src/test/java/com/itsaky/androidide/lsp/java/JavaCompilerProviderTest.kt
+++ b/lsp/java/src/test/java/com/itsaky/androidide/lsp/java/JavaCompilerProviderTest.kt
@@ -60,7 +60,7 @@ class JavaCompilerProviderTest {
     assertThat(compilers).hasSize(5)
 
     compilers.clear()
-    JavaCompilerProvider.getInstance().destory()
+    JavaCompilerProvider.getInstance().destroy()
 
     assertThat(JavaCompilerProvider.get(appModule)).isNotEqualTo(appCompiler)
   }

--- a/subprojects/jdt/src/main/java/org/eclipse/jdt/core/compiler/CharOperation.java
+++ b/subprojects/jdt/src/main/java/org/eclipse/jdt/core/compiler/CharOperation.java
@@ -30,7 +30,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Luiz-Otavio Zorzella <zorzella at gmail dot com> - Improve CamelCase algorithm
- *     Gábor Kövesdán - Contribution for Bug 350000 - [content assist] Include non-prefix matches in auto-complete suggestions
+ *     Gobor Kovesdan - Contribution for Bug 350000 - [content assist] Include non-prefix matches in auto-complete suggestions
  *     Stefan Xenos <sxenos@gmail.com> (Google) - Bug 501283 - Lots of hash collisions during indexing
  *******************************************************************************/
 package org.eclipse.jdt.core.compiler;

--- a/subprojects/tooling-api-model/build.gradle.kts
+++ b/subprojects/tooling-api-model/build.gradle.kts
@@ -32,8 +32,8 @@ dependencies {
 }
 
 tasks.register < Copy > ("copyToTestDir") {
-    from ("$project.buildDir.absolutePath/libs/tooling-api-model.jar")
-    into ("${project.rootProject.file ("tests/test-home/.androidide/init").absolutePath}/")
+    from ("${project.buildDir.absolutePath}/libs/tooling-api-model.jar")
+    into ("${project.rootProject.file("tests/test-home/.androidide/init").absolutePath}/")
     rename { "model.jar" }
     
     outputs.upToDateWhen { false }


### PR DESCRIPTION
… desrtoy renamed to destroy
… Fixed compilation issues for Windows (UTF-8 charset in file CharOperations was incorrect)
… Fixed compilation issue with tooling-api.jar copying to test directory (In Kotlin the long expressions need to be wrapped with {})