### PR TITLE
fix: close others file tab

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/activities/editor/EditorHandlerActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/EditorHandlerActivity.kt
@@ -418,19 +418,14 @@ open class EditorHandlerActivity : ProjectHandlerActivity(), IEditorHandler {
 
     if (unsavedFiles.isEmpty()) {
       val file = viewModel.getCurrentFile()
-      for (i in 0 until viewModel.getOpenedFileCount()) {
-        val editor = getEditorAtIndex(i)
-
-        // Index of files changes as we keep close files
-        // So we compare the files instead of index
-        if (editor != null) {
-          if (file != editor.file) {
-            closeFile(i)
-          }
-        } else {
-          log.error("Unable to save file at index:", i)
-        }
-      }
+      val editor = getCurrentEditor()
+      
+      closeAll()
+      
+      binding.editorContainer.addView(editor)
+      binding.tabs.addTab(binding.tabs.newTab().setText(file.name))
+      
+      viewModel.addFile(file)
     } else {
       notifyFilesUnsaved(unsavedFiles) { closeOthers() }
     }

--- a/app/src/main/java/com/itsaky/androidide/activities/editor/EditorHandlerActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/EditorHandlerActivity.kt
@@ -423,7 +423,7 @@ open class EditorHandlerActivity : ProjectHandlerActivity(), IEditorHandler {
       closeAll()
       
       binding.editorContainer.addView(editor)
-      binding.tabs.addTab(binding.tabs.newTab().setText(file.name))
+      binding.tabs.addTab(binding.tabs.newTab().setText(file!!.name))
       
       viewModel.addFile(file)
     } else {


### PR DESCRIPTION
Before when you clicked to close others there were some files left over, now only the current file will remain 