### PR TITLE
fix: (resources): string "No AndroidX" without space between the two …

### DIFF
--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -113,7 +113,7 @@
   <string name="template_no_activity_description">Creates a new project without activity</string>
 
   <!-- Files -->
-  <string name="template_no_AndroidX">NoAndroidX</string>
+  <string name="template_no_AndroidX">No AndroidX</string>
   <string name="template_description_noAndroidX">Creates a new project without AndroidX library</string>
   <string name="save">Save</string>
   <string name="menu_find">Find</string>


### PR DESCRIPTION
…words

This error causes suggestions for this string in Crowdin to be erroneous, which can lead to it being approved incorrectly, as happened with Portuguese. This simple commit fixes that