### PR TITLE
fix(templates): remove viewBinding build feature from compose templat…

### DIFF
--- a/templates-api/src/main/java/com/itsaky/androidide/templates/base/modules/android/buildGradle.kt
+++ b/templates-api/src/main/java/com/itsaky/androidide/templates/base/modules/android/buildGradle.kt
@@ -76,7 +76,7 @@ android {
     }
 
     buildFeatures {
-        viewBinding = true
+        ${if (!isComposeModule) "viewBinding = true" else ""}
         ${if (isComposeModule) "compose = true" else ""}
     }
     ${if(isComposeModule) composeConfigKts() else ""}
@@ -125,7 +125,7 @@ android {
     }
 
     buildFeatures {
-        viewBinding true
+        ${if (!isComposeModule) "viewBinding true" else ""}
         ${if (isComposeModule) "compose true" else ""}
     }
     ${if(isComposeModule) composeConfigGroovy() else ""}


### PR DESCRIPTION
…e due not necessary

I'm trying to learn a little how the project is structured, so starting with a few things

This build feature is not used when building apps with jetpack compose, so I'm removing it from the build files