### PR TITLE
fix: remove 'buildToolsVersion'  from templates build.gradle files

### DIFF
--- a/app/src/main/res/layout/fragment_empty_state.xml
+++ b/app/src/main/res/layout/fragment_empty_state.xml
@@ -25,6 +25,10 @@
     android:layout_height="match_parent"
     android:background="?attr/colorSurface"
     android:clickable="false"
-    android:focusable="false" />
+    android:focusable="false"
+    android:layout_marginStart="10dp"
+    android:layout_marginEnd="10dp"
+    android:gravity="center"
+    android:layout_gravity="center"/>
 
 </ViewFlipper>

--- a/app/src/main/res/layout/fragment_empty_state.xml
+++ b/app/src/main/res/layout/fragment_empty_state.xml
@@ -22,13 +22,14 @@
   <com.itsaky.androidide.ui.EmptyView
     android:id="@+id/empty_view"
     android:layout_width="match_parent"
+    android:layout_gravity="center"
     android:layout_height="match_parent"
+    android:layout_marginStart="10dp"
+    android:layout_marginEnd="10dp"
     android:background="?attr/colorSurface"
     android:clickable="false"
     android:focusable="false"
-    android:layout_marginStart="10dp"
-    android:layout_marginEnd="10dp"
     android:gravity="center"
-    android:layout_gravity="center"/>
+/>
 
 </ViewFlipper>

--- a/app/src/main/res/layout/fragment_empty_state.xml
+++ b/app/src/main/res/layout/fragment_empty_state.xml
@@ -29,7 +29,6 @@
     android:background="?attr/colorSurface"
     android:clickable="false"
     android:focusable="false"
-    android:gravity="center"
-/>
+    android:gravity="center"/>
 
 </ViewFlipper>

--- a/templates-api/src/main/java/com/itsaky/androidide/templates/base/modules/android/buildGradle.kt
+++ b/templates-api/src/main/java/com/itsaky/androidide/templates/base/modules/android/buildGradle.kt
@@ -97,7 +97,6 @@ plugins {
 android {
     namespace '${data.packageName}'
     compileSdk ${data.versions.compileSdk.api}
-    buildToolsVersion "${data.versions.buildTools}"
 
     defaultConfig {
         applicationId "${data.packageName}"

--- a/templates-api/src/main/java/com/itsaky/androidide/templates/base/modules/android/buildGradle.kt
+++ b/templates-api/src/main/java/com/itsaky/androidide/templates/base/modules/android/buildGradle.kt
@@ -49,7 +49,6 @@ plugins {
 android {
     namespace = "${data.packageName}"
     compileSdk = ${data.versions.compileSdk.api}
-    buildToolsVersion = "${data.versions.buildTools}"
 
     defaultConfig {
         applicationId = "${data.packageName}"

--- a/templates-api/src/main/java/com/itsaky/androidide/templates/constants.kt
+++ b/templates-api/src/main/java/com/itsaky/androidide/templates/constants.kt
@@ -27,7 +27,6 @@ const val KOTLIN_VERSION = "1.8.21"
 
 val TARGET_SDK_VERSION = Sdk.Tiramisu
 val COMPILE_SDK_VERSION = Sdk.Tiramisu
-val BUILD_TOOLS_VERSION = "33.0.2"
 
 const val JAVA_SOURCE_VERSION = "11"
 const val JAVA_TARGET_VERSION = "11"

--- a/templates-api/src/main/java/com/itsaky/androidide/templates/template.kt
+++ b/templates-api/src/main/java/com/itsaky/androidide/templates/template.kt
@@ -178,7 +178,6 @@ data class ProjectVersionData(
 data class ModuleVersionData(val minSdk: Sdk,
                              val targetSdk: Sdk = TARGET_SDK_VERSION,
                              val compileSdk: Sdk = COMPILE_SDK_VERSION,
-                             val buildTools: String = BUILD_TOOLS_VERSION,
                              val javaSource: String = JAVA_SOURCE_VERSION,
                              val javaTarget: String = JAVA_TARGET_VERSION
 ) {


### PR DESCRIPTION
This is no longer necessary as of Android Gradle Plugin version 7.0.0 (and newer) it already uses a defined default version of build tools for each version, which prevents the developer from setting an incompatible version or things like that.