### PR TITLE
fix: remove 'buildToolsVersion'  from templates build.gradle files

### DIFF
--- a/templates-api/src/main/java/com/itsaky/androidide/templates/base/modules/android/buildGradle.kt
+++ b/templates-api/src/main/java/com/itsaky/androidide/templates/base/modules/android/buildGradle.kt
@@ -49,8 +49,7 @@ plugins {
 android {
     namespace = "${data.packageName}"
     compileSdk = ${data.versions.compileSdk.api}
-    buildToolsVersion = "${data.versions.buildTools}"
-
+    
     defaultConfig {
         applicationId = "${data.packageName}"
         minSdk = ${data.versions.minSdk.api}
@@ -98,8 +97,7 @@ plugins {
 android {
     namespace '${data.packageName}'
     compileSdk ${data.versions.compileSdk.api}
-    buildToolsVersion "${data.versions.buildTools}"
-
+    
     defaultConfig {
         applicationId "${data.packageName}"
         minSdk ${data.versions.minSdk.api}

--- a/templates-api/src/main/java/com/itsaky/androidide/templates/constants.kt
+++ b/templates-api/src/main/java/com/itsaky/androidide/templates/constants.kt
@@ -27,7 +27,6 @@ const val KOTLIN_VERSION = "1.8.21"
 
 val TARGET_SDK_VERSION = Sdk.Tiramisu
 val COMPILE_SDK_VERSION = Sdk.Tiramisu
-val BUILD_TOOLS_VERSION = "33.0.2"
 
 const val JAVA_SOURCE_VERSION = "11"
 const val JAVA_TARGET_VERSION = "11"

--- a/templates-api/src/main/java/com/itsaky/androidide/templates/template.kt
+++ b/templates-api/src/main/java/com/itsaky/androidide/templates/template.kt
@@ -175,12 +175,12 @@ data class ProjectVersionData(
  * @property targetSdk The target SDK version for modules.
  * @property buildTools The build tools version for modules.
  */
-data class ModuleVersionData(val minSdk: Sdk,
-                             val targetSdk: Sdk = TARGET_SDK_VERSION,
-                             val compileSdk: Sdk = COMPILE_SDK_VERSION,
-                             val buildTools: String = BUILD_TOOLS_VERSION,
-                             val javaSource: String = JAVA_SOURCE_VERSION,
-                             val javaTarget: String = JAVA_TARGET_VERSION
+data class ModuleVersionData(
+  val minSdk: Sdk,
+  val targetSdk: Sdk = TARGET_SDK_VERSION,
+  val compileSdk: Sdk = COMPILE_SDK_VERSION,
+  val javaSource: String = JAVA_SOURCE_VERSION,
+  val javaTarget: String = JAVA_TARGET_VERSION
 ) {
 
   /**


### PR DESCRIPTION
This is no longer necessary as of Android Gradle Plugin version 7.0.0 (and newer) it already uses a defined default version of build tools for each version, which prevents the developer from setting an incompatible version or things like that.