### PR TITLE
fix(templates): add 'gradlePluginPortal()' to settings.gradle[.kts]

### DIFF
--- a/templates-api/src/main/java/com/itsaky/androidide/templates/base/root/settings.kt
+++ b/templates-api/src/main/java/com/itsaky/androidide/templates/base/root/settings.kt
@@ -23,6 +23,7 @@ internal fun ProjectTemplateBuilder.settingsGradleSrcStr(): String {
   return """
 pluginManagement {
   repositories {
+    gradlePluginPortal()
     google()
     mavenCentral()
   }


### PR DESCRIPTION
fixes people trying to add gradle enterprise to their projects
This plugin is already standard in Android Studio projects