### PR TITLE
fix(settings): single choice prefs not being dismissed when clicking …

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/preferences/editor.kt
+++ b/app/src/main/java/com/itsaky/androidide/preferences/editor.kt
@@ -180,6 +180,11 @@ private class TabSize(
     tabSize = size
   }
 
+  override fun onConfigureDialog(preference: Preference, dialog: MaterialAlertDialogBuilder) {
+    super.onConfigureDialog(preference, dialog)
+    dialog.setCancelable(true)
+  }
+
   override fun getSelectedItem(): Int {
     var current = tabSize / 2 - 1
     if (current < 0 || current >= choices.size) {

--- a/app/src/main/java/com/itsaky/androidide/preferences/editor.kt
+++ b/app/src/main/java/com/itsaky/androidide/preferences/editor.kt
@@ -165,6 +165,7 @@ private class TabSize(
   override val summary: Int? = string.msg_tab_size,
   override val icon: Int? = drawable.ic_font_ligatures,
 ) : SingleChoicePreference() {
+  override val dialogCancellable = true
 
   @IgnoredOnParcel private val choices = arrayOf("2", "4", "6", "8")
 
@@ -178,11 +179,6 @@ private class TabSize(
       size = 4
     }
     tabSize = size
-  }
-
-  override fun onConfigureDialog(preference: Preference, dialog: MaterialAlertDialogBuilder) {
-    super.onConfigureDialog(preference, dialog)
-    dialog.setCancelable(true)
   }
 
   override fun getSelectedItem(): Int {
@@ -201,6 +197,7 @@ private class ColorSchemePreference(
   override val summary: Int? = R.string.idepref_editor_colorScheme_summary,
   override val icon: Int? = R.drawable.ic_color_scheme
 ) : SingleChoicePreference() {
+  override val dialogCancellable = true
 
   @IgnoredOnParcel private val schemes = IDEColorSchemeProvider.list()
 
@@ -216,11 +213,6 @@ private class ColorSchemePreference(
     if (isSelected) {
       colorScheme = schemes[position].key
     }
-  }
-
-  override fun onConfigureDialog(preference: Preference, dialog: MaterialAlertDialogBuilder) {
-    super.onConfigureDialog(preference, dialog)
-    dialog.setCancelable(true)
   }
 }
 

--- a/app/src/main/java/com/itsaky/androidide/preferences/general.kt
+++ b/app/src/main/java/com/itsaky/androidide/preferences/general.kt
@@ -119,6 +119,7 @@ class UiMode(
       uiMode = mode
     }
   }
+  
   override fun onConfigureDialog(preference: Preference, dialog: MaterialAlertDialogBuilder) {
     super.onConfigureDialog(preference, dialog)
     dialog.setCancelable(true)

--- a/app/src/main/java/com/itsaky/androidide/preferences/general.kt
+++ b/app/src/main/java/com/itsaky/androidide/preferences/general.kt
@@ -20,7 +20,6 @@ package com.itsaky.androidide.preferences
 import android.content.Context
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.Preference
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.itsaky.androidide.R
 import com.itsaky.androidide.preferences.internal.CONFIRM_PROJECT_OPEN
 import com.itsaky.androidide.preferences.internal.ENABLE_MATERIAL_YOU
@@ -92,6 +91,8 @@ class UiMode(
   override val summary: Int? = R.string.idepref_general_uiMode_summary,
   override val icon: Int? = R.drawable.ic_ui_mode
 ) : SingleChoicePreference() {
+  override val dialogCancellable = true
+
   override fun getChoices(context: Context): Array<String> {
     return arrayOf(
       context.getString(R.string.uiMode_light),
@@ -118,11 +119,6 @@ class UiMode(
         }
       uiMode = mode
     }
-  }
-  
-  override fun onConfigureDialog(preference: Preference, dialog: MaterialAlertDialogBuilder) {
-    super.onConfigureDialog(preference, dialog)
-    dialog.setCancelable(true)
   }
 }
 

--- a/app/src/main/java/com/itsaky/androidide/preferences/general.kt
+++ b/app/src/main/java/com/itsaky/androidide/preferences/general.kt
@@ -20,6 +20,7 @@ package com.itsaky.androidide.preferences
 import android.content.Context
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.Preference
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.itsaky.androidide.R
 import com.itsaky.androidide.preferences.internal.CONFIRM_PROJECT_OPEN
 import com.itsaky.androidide.preferences.internal.ENABLE_MATERIAL_YOU
@@ -117,6 +118,10 @@ class UiMode(
         }
       uiMode = mode
     }
+  }
+  override fun onConfigureDialog(preference: Preference, dialog: MaterialAlertDialogBuilder) {
+    super.onConfigureDialog(preference, dialog)
+    dialog.setCancelable(true)
   }
 }
 

--- a/app/src/main/java/com/itsaky/androidide/preferences/xmlPrefs.kt
+++ b/app/src/main/java/com/itsaky/androidide/preferences/xmlPrefs.kt
@@ -18,6 +18,8 @@
 package com.itsaky.androidide.preferences
 
 import android.content.Context
+import androidx.preference.Preference
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.itsaky.androidide.resources.R.string
 import com.itsaky.androidide.preferences.internal.CLOSING_BRACKET_NEW_LINE
 import com.itsaky.androidide.preferences.internal.EMPTY_ELEMENTS_BEHAVIOR
@@ -237,4 +239,10 @@ private class EmptyElementsBehavior(
   override fun onItemSelected(position: Int, isSelected: Boolean) {
     emptyElementsBehavior = EmptyElements.values()[position].toString()
   }
+  
+  override fun onConfigureDialog(preference: Preference, dialog: MaterialAlertDialogBuilder) {
+    super.onConfigureDialog(preference, dialog)
+    dialog.setCancelable(true)
+  }
+
 }

--- a/app/src/main/java/com/itsaky/androidide/preferences/xmlPrefs.kt
+++ b/app/src/main/java/com/itsaky/androidide/preferences/xmlPrefs.kt
@@ -18,8 +18,6 @@
 package com.itsaky.androidide.preferences
 
 import android.content.Context
-import androidx.preference.Preference
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.itsaky.androidide.resources.R.string
 import com.itsaky.androidide.preferences.internal.CLOSING_BRACKET_NEW_LINE
 import com.itsaky.androidide.preferences.internal.EMPTY_ELEMENTS_BEHAVIOR
@@ -227,6 +225,7 @@ private class EmptyElementsBehavior(
   override val title: Int = string.idepref_emptyElements_title,
   override val summary: Int? = string.idepref_emptyElements_summary
 ) : SingleChoicePreference() {
+  override val dialogCancellable = true
 
   override fun getSelectedItem(): Int {
     return EmptyElements.valueOf(emptyElementsBehavior).ordinal
@@ -239,10 +238,4 @@ private class EmptyElementsBehavior(
   override fun onItemSelected(position: Int, isSelected: Boolean) {
     emptyElementsBehavior = EmptyElements.values()[position].toString()
   }
-  
-  override fun onConfigureDialog(preference: Preference, dialog: MaterialAlertDialogBuilder) {
-    super.onConfigureDialog(preference, dialog)
-    dialog.setCancelable(true)
-  }
-
 }


### PR DESCRIPTION
…outside the dialog

Some preferences that do not have an "ok" or "cancel" button forced us to click on the choice again so that the card disappeared

Now the following preferences are dismissible:
- UI Mode (Theme)
- Tab Size
- Empty elements behavior