### PR TITLE
fix: allow armeabi-v7a on arm64-v8a

### DIFF
--- a/common/src/main/java/com/itsaky/androidide/app/BaseApplication.java
+++ b/common/src/main/java/com/itsaky/androidide/app/BaseApplication.java
@@ -35,7 +35,9 @@ import com.itsaky.androidide.utils.FlashbarUtilsKt;
 import com.itsaky.androidide.utils.JavaCharacter;
 import com.itsaky.androidide.utils.VMUtils;
 import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import kotlin.collections.ArraysKt;
 
 public class BaseApplication extends Application {
@@ -46,6 +48,7 @@ public class BaseApplication extends Application {
   public static final String SPONSOR_URL = BuildInfo.PROJECT_SITE + "/donate";
   public static final String DOCS_URL = BuildInfo.PROJECT_SITE + "/docs";
   public static final String EMAIL = "contact@androidide.com";
+  public static final String ASSETS_DATA_DIR = "data";
   private static final String AARCH64 = "arm64-v8a";
   private static final String ARM = "armeabi-v7a";
   private static BaseApplication instance;
@@ -53,6 +56,10 @@ public class BaseApplication extends Application {
 
   public static BaseApplication getBaseInstance() {
     return instance;
+  }
+
+  public static List<String> listAssetsDataDirectory() throws IOException {
+    return Arrays.asList(getBaseInstance().getAssets().list(ASSETS_DATA_DIR));
   }
 
   public static boolean isAbiSupported() {

--- a/common/src/main/java/com/itsaky/androidide/managers/ToolsManager.java
+++ b/common/src/main/java/com/itsaky/androidide/managers/ToolsManager.java
@@ -17,6 +17,7 @@
  */
 package com.itsaky.androidide.managers;
 
+import android.os.Build;
 import androidx.annotation.NonNull;
 import com.blankj.utilcode.util.FileIOUtils;
 import com.blankj.utilcode.util.FileUtils;
@@ -30,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import org.jetbrains.annotations.Contract;
@@ -37,8 +39,7 @@ import org.jetbrains.annotations.Contract;
 public class ToolsManager {
 
   private static final ILogger LOG = ILogger.newInstance("ToolsManager");
-  public static String ARCH_SPECIFIC_ASSET_DATA_DIR = "data/" + BaseApplication.getArch();
-  public static String COMMON_ASSET_DATA_DIR = "data/common";
+  public static String COMMON_ASSET_DATA_DIR = BaseApplication.ASSETS_DATA_DIR + "/common";
 
   public static void init(@NonNull BaseApplication app, Runnable onFinish) {
 
@@ -182,7 +183,19 @@ public class ToolsManager {
   @NonNull
   @Contract(pure = true)
   public static String getArchSpecificAsset(String name) {
-    return ARCH_SPECIFIC_ASSET_DATA_DIR + "/" + name;
+    try {
+      List<String> dataDirItems = BaseApplication.listAssetsDataDirectory();
+
+      for (String abi : Build.SUPPORTED_ABIS) {
+        if (dataDirItems.contains(abi)) {
+          return String.format("%s/%s/%s", BaseApplication.ASSETS_DATA_DIR, abi, name);
+        }
+      }
+    } catch (IOException exception) {
+      throw new RuntimeException(exception);
+    }
+
+    throw new RuntimeException("This build doesn't contain any compatible file for " + name);
   }
 
   @NonNull


### PR DESCRIPTION
Currently the AndroidIDE application uses a hardcoded path to access the required files, which causes FCs.

And here is my solution to fix it:
- Scan existing architectures in the application and system
- Select the first matching architecture folder and use it

This code can be useful to prevent crashes if the system has supported instructions.