### PR TITLE
fix(uidesigner): IndexOutOfBoundsException error when deleting an attribute (closes #1375) 

### DIFF
--- a/uidesigner/src/main/java/com/itsaky/androidide/uidesigner/adapters/ViewAttrListAdapter.kt
+++ b/uidesigner/src/main/java/com/itsaky/androidide/uidesigner/adapters/ViewAttrListAdapter.kt
@@ -92,9 +92,11 @@ internal class ViewAttrListAdapter(
         message = context.getString(R.string.msg_confirm_delete, attribute.qualifiedName),
         positiveClickListener = { dialog, _ ->
           dialog.dismiss()
-          if (onDeleteAttr(attribute)) {
-            this.attributes.removeAt(position)
-            notifyItemRemoved(position)
+          if (position >= 0 || position < this.attributes.size) {
+            if (onDeleteAttr(attribute)) {
+              this.attributes.removeAt(position)
+              notifyItemRemoved(position)
+            }
           }
         }
       )


### PR DESCRIPTION
I added an index check of the position being deleted, because when the user double clicks to delete the attribute, 2 dialog boxes appear and if the user deletes the attribute with the first dialog box, when he tries to delete the attribute with In the second dialog box, the error ```IndexOutOfBoundsException``` occurs. With this the problem will be solved 