### PR TITLE
[Feature] Replace ic_close with ic_sweep_delete on the "Clear logs" FAB

### DIFF
--- a/app/src/main/res/layout/layout_editor_bottom_sheet.xml
+++ b/app/src/main/res/layout/layout_editor_bottom_sheet.xml
@@ -83,7 +83,7 @@
     android:layout_above="@id/space_bottom"
     android:layout_alignParentEnd="true"
     android:layout_margin="16dp"
-    android:src="@drawable/ic_close" />
+    android:src="@drawable/ic_sweep_delete" />
 
   <com.google.android.material.floatingactionbutton.FloatingActionButton
     android:id="@+id/share_output_fab"

--- a/resources/src/main/res/drawable/ic_sweep_delete.xml
+++ b/resources/src/main/res/drawable/ic_sweep_delete.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M15,16h4v2h-4zM15,8h7v2h-7zM15,12h6v2h-6zM3,18c0,1.1 0.9,2 2,2h6c1.1,0 2,-0.9 2,-2L13,8L3,8v10zM5,10h6v8L5,18v-8zM10,4L6,4L5,5L2,5v2h12L14,5h-3z"/>
+</vector>


### PR DESCRIPTION
This pull request replaces [ic_close](https://github.com/AndroidIDEOfficial/AndroidIDE/blob/42ae28a0b9f4d9b0e5db7939ff7fa11202e848d0/resources/src/main/res/drawable/ic_close.xml) with [ic_sweep_delete](https://pictogrammers.com/library/mdi/icon/delete-sweep-outline/) on the floating action button inside the editor bottom sheet.

<details>
<summary><b>🖼️ Comparison before / after</b></summary>
<br>

| Before | After |
| ------ | ----- |
| ![Before](https://github.com/AndroidIDEOfficial/AndroidIDE/assets/71522503/5c5e334c-e88c-46ee-a7f1-383fb6c618ce) | ![After](https://github.com/AndroidIDEOfficial/AndroidIDE/assets/71522503/8a303f27-3c0d-4bdc-a4c8-10c5ba24d290)|

</details>

This new icon delivers the meaning of this button better. The old one might be interpreted as "Close bottom sheet" or "Cancel current task" for example.