### PR TITLE
fix: avoid recreating build service when changing theme

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,7 +60,7 @@
       android:theme="@style/Theme.AndroidIDE"/>
     <activity
       android:name=".activities.editor.EditorActivityKt"
-      android:configChanges="orientation|screenSize"
+      android:configChanges="uiMode|orientation|screenSize"
       android:launchMode="singleTop"
       android:windowSoftInputMode="adjustResize" />
     <activity android:name=".activities.PreferencesActivity" />
@@ -69,7 +69,7 @@
       android:configChanges="orientation|screenSize" />
     <activity
       android:name=".activities.TerminalActivity"
-      android:configChanges="orientation|screenSize"
+      android:configChanges="uiMode|orientation|screenSize"
       android:windowSoftInputMode="adjustResize" />
 
     <service


### PR DESCRIPTION
1 - This should prevent the build service from being rebuilt every time you change the device theme and this initialization error is generated

```
EditorActivity            W   GradleProject has already been initialized. Skipping initialization process. 
EditorActivity            E   An error occurred initializing the project with Tooling API  null 
```

2 - It should also fix the terminal being rebuilt and losing all content, for the same reason