### PR TITLE
[FIX] Replace *Swipe right for files* with *Open the left drawer for files*

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.21" />
+    <option name="version" value="1.9.22" />
   </component>
 </project>

--- a/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -510,7 +510,7 @@ abstract class BaseEditorActivity :
         }
       }
     val sb = SpannableStringBuilder()
-    appendClickableSpan(sb, string.msg_swipe_for_files, filesSpan)
+    appendClickableSpan(sb, string.msg_drawer_for_files, filesSpan)
     appendClickableSpan(sb, string.msg_swipe_for_output, bottomSheetSpan)
     binding.noEditorSummary.text = sb
   }

--- a/resources/src/main/res/values-ar-rSA/strings.xml
+++ b/resources/src/main/res/values-ar-rSA/strings.xml
@@ -230,7 +230,6 @@
   <string name="idepref_useIcu_summary">استخدم مكتبة ICU لاستخدام استعادة حواف الكلمات للنقر المزدوج والضغط المطول على اختيار الكلمات.</string>
   <!--The text sorrounded with '@@' is spanned as clickable.-->
   <!--There must be exactly two '@@' sorrounding the text that should be clickable.-->
-  <string name="msg_swipe_for_files">اسحب لليسار لعرض @@الملفات@@</string>
   <string name="msg_swipe_for_output">مرر لأعلى لعرض @@مخرجات البناء@@</string>
   <string name="idepref_editor_useSoftTabs_title">استخدام علامة التبويب الناعمة</string>
   <string name="idepref_editor_useSoftTabs_summary">اختر ما إذا كان سيتم استخدام المسافات بدلاً من حرف التبويب (\\t).</string>
@@ -426,7 +425,7 @@
   <string name="idepref_launchAppAfterInstall_title">Launch app after installation</string>
   <string name="idepref_launchAppAfterInstall_summary">If enabled, the IDE will (without confirmation) launch the application right after it is installed.</string>
   <string name="title_run_options">Run options</string>
-  <string name="err_cannot_determine_package">Cannot run app. Unable to determine package name.</string>
+  <string name="err_cannot_determine_package">Cannot run application. Unable to determine package name.</string>
   <string name="msg_launch_failure_no_app_module">Cannot run application. No application modules found in project.</string>
   <string name="title_launch_app">Launch app</string>
   <string name="title_experiment_flavor">Experimental</string>

--- a/resources/src/main/res/values-bn-rIN/strings.xml
+++ b/resources/src/main/res/values-bn-rIN/strings.xml
@@ -231,7 +231,6 @@
   <string name="idepref_useIcu_summary">ডাবল-ট্যাপ এবং দীর্ঘক্ষণ চাপা শব্দ নির্বাচনের জন্য ICU লাইব্রেরি ব্যবহার করুন৷</string>
   <!--The text sorrounded with '@@' is spanned as clickable.-->
   <!--There must be exactly two '@@' sorrounding the text that should be clickable.-->
-  <string name="msg_swipe_for_files">\@@ফাইল গুলি@@র জন্য বাম দিকে সোয়াইপ করুন।</string>
   <string name="msg_swipe_for_output">\@@বিল্ড আউটপুট@@ এর জন্য উপরে সোয়াইপ করুন।</string>
   <string name="idepref_editor_useSoftTabs_title">সফ্ট ট্যাব ব্যবহার করুন</string>
   <string name="idepref_editor_useSoftTabs_summary">ট্যাব অক্ষরের (\\t) পরিবর্তে স্পেস ব্যবহার করবেন কিনা তা বেছে নিন।</string>

--- a/resources/src/main/res/values-de-rDE/strings.xml
+++ b/resources/src/main/res/values-de-rDE/strings.xml
@@ -230,7 +230,6 @@
   <string name="idepref_useIcu_summary">Use ICU library to use retrive word edges for double-tap and long-press word selection.</string>
   <!--The text sorrounded with '@@' is spanned as clickable.-->
   <!--There must be exactly two '@@' sorrounding the text that should be clickable.-->
-  <string name="msg_swipe_for_files">Nach Links swipen für @@files@@.</string>
   <string name="msg_swipe_for_output">Swipe nach oben für @@build output@@.</string>
   <string name="idepref_editor_useSoftTabs_title">Soft tab benutzen</string>
   <string name="idepref_editor_useSoftTabs_summary">Wählen Sie, ob Leerzeichen anstelle von Tab verwendet werden sollen (\\t).</string>

--- a/resources/src/main/res/values-es-rES/strings.xml
+++ b/resources/src/main/res/values-es-rES/strings.xml
@@ -425,7 +425,7 @@
   <string name="idepref_launchAppAfterInstall_title">Launch app after installation</string>
   <string name="idepref_launchAppAfterInstall_summary">If enabled, the IDE will (without confirmation) launch the application right after it is installed.</string>
   <string name="title_run_options">Run options</string>
-  <string name="err_cannot_determine_package">Cannot run app. Unable to determine package name.</string>
+  <string name="err_cannot_determine_package">Cannot run application. Unable to determine package name.</string>
   <string name="msg_launch_failure_no_app_module">Cannot run application. No application modules found in project.</string>
   <string name="title_launch_app">Launch app</string>
   <string name="title_experiment_flavor">Experimental</string>

--- a/resources/src/main/res/values-es-rES/strings.xml
+++ b/resources/src/main/res/values-es-rES/strings.xml
@@ -230,7 +230,6 @@
   <string name="idepref_useIcu_summary">Utilice la librería ICU para recuperar los bordes de palabras para doble toque y selección de palabras con pulsación larga.</string>
   <!--The text sorrounded with '@@' is spanned as clickable.-->
   <!--There must be exactly two '@@' sorrounding the text that should be clickable.-->
-  <string name="msg_swipe_for_files">Deslice a la izquierda para ver @@Archivos@@.</string>
   <string name="msg_swipe_for_output">Desliza hacia arriba para ver el @@Registro@@.</string>
   <string name="idepref_editor_useSoftTabs_title">Usar pestaña flexible</string>
   <string name="idepref_editor_useSoftTabs_summary">Elija si desea utilizar espacios en lugar del carácter de pestaña (\\t).</string>

--- a/resources/src/main/res/values-fr-rFR/strings.xml
+++ b/resources/src/main/res/values-fr-rFR/strings.xml
@@ -231,7 +231,6 @@ Dernier projet ouvert : \n%s</string>
   <string name="idepref_useIcu_summary">Use ICU library to use retrive word edges for double-tap and long-press word selection.</string>
   <!--The text sorrounded with '@@' is spanned as clickable.-->
   <!--There must be exactly two '@@' sorrounding the text that should be clickable.-->
-  <string name="msg_swipe_for_files">Swipez de droite à gauche pour accéder aux @@fichiers@@.</string>
   <string name="msg_swipe_for_output">Tirez du bas vers le haut pour accéder aux @@consoles (application, ide et compilation)@@.</string>
   <string name="idepref_editor_useSoftTabs_title">Use soft tab</string>
   <string name="idepref_editor_useSoftTabs_summary">Choose whether to use spaces instead of tab character (\\t).</string>

--- a/resources/src/main/res/values-fr-rFR/strings.xml
+++ b/resources/src/main/res/values-fr-rFR/strings.xml
@@ -426,7 +426,7 @@ Dernier projet ouvert : \n%s</string>
   <string name="idepref_launchAppAfterInstall_title">Launch app after installation</string>
   <string name="idepref_launchAppAfterInstall_summary">If enabled, the IDE will (without confirmation) launch the application right after it is installed.</string>
   <string name="title_run_options">Run options</string>
-  <string name="err_cannot_determine_package">Cannot run app. Unable to determine package name.</string>
+  <string name="err_cannot_determine_package">Cannot run application. Unable to determine package name.</string>
   <string name="msg_launch_failure_no_app_module">Cannot run application. No application modules found in project.</string>
   <string name="title_launch_app">Launch app</string>
   <string name="title_experiment_flavor">Experimental</string>

--- a/resources/src/main/res/values-hi-rIN/strings.xml
+++ b/resources/src/main/res/values-hi-rIN/strings.xml
@@ -230,7 +230,6 @@
   <string name="idepref_useIcu_summary">डबल-टैप और लंबे समय तक शब्द चयन के लिए शब्द किनारों को पुनः प्राप्त करने के लिए ICU लाइब्रेरी का उपयोग करें।</string>
   <!--The text sorrounded with '@@' is spanned as clickable.-->
   <!--There must be exactly two '@@' sorrounding the text that should be clickable.-->
-  <string name="msg_swipe_for_files">\@@फाइल्स@@ के लिए बाएं स्वाइप करें।</string>
   <string name="msg_swipe_for_output">\@@बिल्ड आउटपुट@@ के लिए ऊपर स्वाइप करें।</string>
   <string name="idepref_editor_useSoftTabs_title">सॉफ्ट टैब का उपयोग करें</string>
   <string name="idepref_editor_useSoftTabs_summary">चुनें कि टैब वर्ण (\\t) के बजाय रिक्त स्थान का उपयोग करना है या नहीं।</string>

--- a/resources/src/main/res/values-in-rID/strings.xml
+++ b/resources/src/main/res/values-in-rID/strings.xml
@@ -230,7 +230,6 @@
   <string name="idepref_useIcu_summary">Gunakan perpustakaan ICU untuk menggunakan ambil tepi kata untuk pemilihan kata ketuk dua kali dan tekan lama.</string>
   <!--The text sorrounded with '@@' is spanned as clickable.-->
   <!--There must be exactly two '@@' sorrounding the text that should be clickable.-->
-  <string name="msg_swipe_for_files">Geser ke kiri untuk @@file@@.</string>
   <string name="msg_swipe_for_output">Geser ke atas untuk @@build output@@.</string>
   <string name="idepref_editor_useSoftTabs_title">Gunakan soft tab</string>
   <string name="idepref_editor_useSoftTabs_summary">Pilih apakah akan menggunakan spasi alih-alih karakter tab (\\t).</string>

--- a/resources/src/main/res/values-pt-rBR/strings.xml
+++ b/resources/src/main/res/values-pt-rBR/strings.xml
@@ -230,7 +230,6 @@
   <string name="idepref_useIcu_summary">Usa a biblioteca ICU para usar bordas de palavras de recuperação para seleção de palavras de toque duplo e pressionamento longo.</string>
   <!--The text sorrounded with '@@' is spanned as clickable.-->
   <!--There must be exactly two '@@' sorrounding the text that should be clickable.-->
-  <string name="msg_swipe_for_files">Deslize à esquerda para @@arquivos@@.</string>
   <string name="msg_swipe_for_output">Deslize à cima para @@saída de compilação@@.</string>
   <string name="idepref_editor_useSoftTabs_title">Usar tabulação suave</string>
   <string name="idepref_editor_useSoftTabs_summary">Escolha se deseja usar espaços em vez de caracteres de tabulação (\\t).</string>

--- a/resources/src/main/res/values-ro-rRO/strings.xml
+++ b/resources/src/main/res/values-ro-rRO/strings.xml
@@ -425,7 +425,7 @@
   <string name="idepref_launchAppAfterInstall_title">Launch app after installation</string>
   <string name="idepref_launchAppAfterInstall_summary">If enabled, the IDE will (without confirmation) launch the application right after it is installed.</string>
   <string name="title_run_options">Run options</string>
-  <string name="err_cannot_determine_package">Cannot run app. Unable to determine package name.</string>
+  <string name="err_cannot_determine_package">Cannot run application. Unable to determine package name.</string>
   <string name="msg_launch_failure_no_app_module">Cannot run application. No application modules found in project.</string>
   <string name="title_launch_app">Launch app</string>
   <string name="title_experiment_flavor">Experimental</string>

--- a/resources/src/main/res/values-ro-rRO/strings.xml
+++ b/resources/src/main/res/values-ro-rRO/strings.xml
@@ -230,7 +230,6 @@
   <string name="idepref_useIcu_summary">Use ICU library to use retrive word edges for double-tap and long-press word selection.</string>
   <!--The text sorrounded with '@@' is spanned as clickable.-->
   <!--There must be exactly two '@@' sorrounding the text that should be clickable.-->
-  <string name="msg_swipe_for_files">Swipe left for @@files@@.</string>
   <string name="msg_swipe_for_output">Swipe up for @@build output@@.</string>
   <string name="idepref_editor_useSoftTabs_title">Use soft tab</string>
   <string name="idepref_editor_useSoftTabs_summary">Choose whether to use spaces instead of tab character (\\t).</string>

--- a/resources/src/main/res/values-ru-rRU/strings.xml
+++ b/resources/src/main/res/values-ru-rRU/strings.xml
@@ -230,7 +230,7 @@
   <string name="idepref_useIcu_summary">Использовать библиотеку ICU, чтобы повторно использовать края слов для выбора слова двойным касанием и длительным нажатием.</string>
   <!--The text sorrounded with '@@' is spanned as clickable.-->
   <!--There must be exactly two '@@' sorrounding the text that should be clickable.-->
-  <string name="msg_swipe_for_files">Проведите влево для просмотра @@файлов@@.</string>
+  <string name="msg_drawer_for_files">Откройте боковое меню для просмотра @@дерева файлов@@.</string>
   <string name="msg_swipe_for_output">Проведите вверх для просмотра @@вывода сборки@@.</string>
   <string name="idepref_editor_useSoftTabs_title">Используйте программную вкладку</string>
   <string name="idepref_editor_useSoftTabs_summary">Выберите, следует ли использовать пробелы вместо символа табуляции (\\t).</string>

--- a/resources/src/main/res/values-ru-rRU/strings.xml
+++ b/resources/src/main/res/values-ru-rRU/strings.xml
@@ -230,7 +230,7 @@
   <string name="idepref_useIcu_summary">Использовать библиотеку ICU, чтобы повторно использовать края слов для выбора слова двойным касанием и длительным нажатием.</string>
   <!--The text sorrounded with '@@' is spanned as clickable.-->
   <!--There must be exactly two '@@' sorrounding the text that should be clickable.-->
-  <string name="msg_drawer_for_files">Откройте боковое меню для просмотра @@дерева файлов@@.</string>
+  <string name="msg_drawer_for_files">Боковое меню содержит @@дерево файлов@@.</string>
   <string name="msg_swipe_for_output">Проведите вверх для просмотра @@вывода сборки@@.</string>
   <string name="idepref_editor_useSoftTabs_title">Используйте программную вкладку</string>
   <string name="idepref_editor_useSoftTabs_summary">Выберите, следует ли использовать пробелы вместо символа табуляции (\\t).</string>

--- a/resources/src/main/res/values-tr-rTR/strings.xml
+++ b/resources/src/main/res/values-tr-rTR/strings.xml
@@ -230,7 +230,6 @@
   <string name="idepref_useIcu_summary">Çift dokunma ve uzun basma eylemlerinde sözcükleri almak için ICU kütüphanesini kullan.</string>
   <!--The text sorrounded with '@@' is spanned as clickable.-->
   <!--There must be exactly two '@@' sorrounding the text that should be clickable.-->
-  <string name="msg_swipe_for_files">\@@Dosyalar@@ için sola kaydırın.</string>
   <string name="msg_swipe_for_output">\@@İnşa çıktısı@@ için yukarı kaydırın.</string>
   <string name="idepref_editor_useSoftTabs_title">Yumuşak tab kullan</string>
   <string name="idepref_editor_useSoftTabs_summary">Tab karakteri (\\t) yerine boşluklar kullanmak isteyip istemediğinizi seçin.</string>

--- a/resources/src/main/res/values-zh-rCN/strings.xml
+++ b/resources/src/main/res/values-zh-rCN/strings.xml
@@ -230,7 +230,6 @@
   <string name="idepref_useIcu_summary">使用 ICU 库以检索字词边缘进行双击和长按字词的选择</string>
   <!--The text sorrounded with '@@' is spanned as clickable.-->
   <!--There must be exactly two '@@' sorrounding the text that should be clickable.-->
-  <string name="msg_swipe_for_files">左滑打开 @@文件列表@@</string>
   <string name="msg_swipe_for_output">上滑查看 @@构建输出@@</string>
   <string name="idepref_editor_useSoftTabs_title">使用空格代替制表符</string>
   <string name="idepref_editor_useSoftTabs_summary">设置是否使用多个空格代替制表符 (\\t)</string>

--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -502,7 +502,7 @@
   <string name="idepref_launchAppAfterInstall_title">Launch app after installation</string>
   <string name="idepref_launchAppAfterInstall_summary">If enabled, the IDE will (without confirmation) launch the application right after it is installed.</string>
   <string name="title_run_options">Run options</string>
-  <string name="err_cannot_determine_package">Cannot run app. Unable to determine package name.</string>
+  <string name="err_cannot_determine_package">Cannot run application. Unable to determine package name.</string>
   <string name="msg_launch_failure_no_app_module">Cannot run application. No application modules found in project.</string>
   <string name="title_launch_app">Launch app</string>
   <string name="title_experiment_flavor">Experimental</string>

--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -251,7 +251,7 @@
 
   <!--The text sorrounded with '@@' is spanned as clickable.-->
   <!--There must be exactly two '@@' sorrounding the text that should be clickable.-->
-  <string name="msg_swipe_for_files">Swipe from the left for @@files@@.</string>
+  <string name="msg_drawer_for_files">Open the left drawer for @@files@@.</string>
   <string name="msg_swipe_for_output">Swipe up for @@build output@@.</string>
   <string name="idepref_editor_useSoftTabs_title">Use soft tab</string>
   <string name="idepref_editor_useSoftTabs_summary">Choose whether to use spaces instead of tab character (\\t).</string>


### PR DESCRIPTION
This pull request replaces the `msg_swipe_for_files` string with a different one. This solves the issue that on AOSP-based Android 11+ systems in some configurations it is impossible to swipe from the edge to open the drawer. The new string accounts for that saying *"Open the left drawer for files"*.

I also renamed the string resource and deleted all occurrences of `msg_swipe_for_files` in other languages. This will cause the new string to appear on Crowdin for translation.

Additionally I added a Russian translation for the new string and changed *"Cannot run app"* to *"Cannot run application"* in `err_cannot_determine_package` for it to be consistent with `msg_launch_failure_no_app_module` (for all languages that use similar wording).

| English: *Open the left drawer for files* | Russian: *Side menu pane contains the file tree* |
| --- | --- |
| ![Open the left drawer for files - English](https://github.com/AndroidIDEOfficial/AndroidIDE/assets/71522503/65e60987-8bb3-4a55-818b-d97cb59ded14) | ![Side menu pane contains the file tree - Russian](https://github.com/AndroidIDEOfficial/AndroidIDE/assets/71522503/a2f9db98-ee9c-401d-8cb3-86c901a71484) |

