### PR TITLE
[FEATURE] Better editor tabs

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/activities/editor/EditorHandlerActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/EditorHandlerActivity.kt
@@ -21,19 +21,14 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Bundle
 import android.text.TextUtils
-import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import android.view.ViewGroup.LayoutParams
-import android.widget.LinearLayout
-import android.widget.TextView
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.collection.MutableIntObjectMap
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.GravityCompat
-import androidx.core.view.children
 import com.blankj.utilcode.util.ImageUtils
-import com.google.android.material.tabs.TabLayout
 import com.itsaky.androidide.R.string
 import com.itsaky.androidide.actions.ActionData
 import com.itsaky.androidide.actions.ActionItem.Location.EDITOR_TOOLBAR
@@ -680,8 +675,6 @@ open class EditorHandlerActivity : ProjectHandlerActivity(), IEditorHandler {
       val nameBuilder = UniqueNameBuilder<File>("", File.separator)
 
       val icons = MutableIntObjectMap<Int>()
-      val theme = theme
-      val resources = resources
 
       files.forEach {
         var count = dupliCount[it.name] ?: 0

--- a/app/src/main/java/com/itsaky/androidide/adapters/viewholders/FileTreeViewHolder.java
+++ b/app/src/main/java/com/itsaky/androidide/adapters/viewholders/FileTreeViewHolder.java
@@ -91,19 +91,6 @@ public class FileTreeViewHolder extends TreeNode.BaseNodeViewHolder<File> {
   }
 
   protected int getIconForFile(final File file) {
-
-    if (file.isDirectory()) {
-      return R.drawable.ic_folder;
-    }
-
-    if (ImageUtils.isImage(file)) {
-      return R.drawable.ic_file_image;
-    }
-
-    if ("gradlew".equals(file.getName()) || "gradlew.bat".equals(file.getName())) {
-      return R.drawable.ic_terminal;
-    }
-
     return FileExtension.Factory.forFile(file).getIcon();
   }
 

--- a/app/src/main/java/com/itsaky/androidide/adapters/viewholders/FileTreeViewHolder.java
+++ b/app/src/main/java/com/itsaky/androidide/adapters/viewholders/FileTreeViewHolder.java
@@ -28,7 +28,6 @@ import android.widget.LinearLayout;
 import androidx.transition.ChangeImageTransform;
 import androidx.transition.TransitionManager;
 
-import com.blankj.utilcode.util.ImageUtils;
 import com.blankj.utilcode.util.SizeUtils;
 import com.itsaky.androidide.databinding.LayoutFiletreeItemBinding;
 import com.itsaky.androidide.models.FileExtension;

--- a/app/src/main/java/com/itsaky/androidide/models/FileExtension.kt
+++ b/app/src/main/java/com/itsaky/androidide/models/FileExtension.kt
@@ -69,7 +69,7 @@ enum class FileExtension(val extension: String, @DrawableRes val icon: Int) {
           return UNKNOWN
         }
         
-        for (value in values()) {
+        for (value in entries) {
           if (value.extension == extension) {
             return value
           }

--- a/app/src/main/java/com/itsaky/androidide/models/FileExtension.kt
+++ b/app/src/main/java/com/itsaky/androidide/models/FileExtension.kt
@@ -18,6 +18,7 @@
 package com.itsaky.androidide.models
 
 import androidx.annotation.DrawableRes
+import com.blankj.utilcode.util.ImageUtils
 import com.itsaky.androidide.resources.R
 import java.io.File
 
@@ -40,6 +41,10 @@ enum class FileExtension(val extension: String, @DrawableRes val icon: Int) {
   LOG("log", R.drawable.ic_file_txt),
   CPP("cpp", R.drawable.ic_language_cpp),
   H("h", R.drawable.ic_language_cpp),
+  BAT("bat", R.drawable.ic_terminal),
+  DIRECTORY("", R.drawable.ic_folder),
+  IMAGE("", R.drawable.ic_file_image),
+  GRADLEW("", R.drawable.ic_terminal),
   UNKNOWN("", R.drawable.ic_file_unknown);
 
   /** Factory class for getting [FileExtension] instances. */
@@ -49,13 +54,18 @@ enum class FileExtension(val extension: String, @DrawableRes val icon: Int) {
       /** Get [FileExtension] for the given file. */
       @JvmStatic
       fun forFile(file: File?): FileExtension {
-        return forExtension(file?.extension)
+        return if (file?.isDirectory == true) DIRECTORY
+          else if (ImageUtils.isImage(file)) IMAGE
+          else if ("gradlew" == file?.name) GRADLEW
+          else forExtension(file?.extension)
       }
 
       /** Get [FileExtension] for the given extension. */
       @JvmStatic
       fun forExtension(extension: String?): FileExtension {
-        if (extension == null) {
+        // To not assign IMAGE, GRADLEW and DIRECTORY in case of an empty extension,
+        // we check if an extension is empty here
+        if (extension.isNullOrEmpty()) {
           return UNKNOWN
         }
         

--- a/resources/src/main/res/values/styles.xml
+++ b/resources/src/main/res/values/styles.xml
@@ -80,7 +80,10 @@
     <item name="tabIndicatorGravity">bottom</item>
     <item name="tabIndicatorHeight">3dp</item>
     <item name="tabMode">scrollable</item>
-    <item name="tabMaxWidth">0dp</item>
+    <!-- Increase tab width according to their title -->
+    <item name="tabMaxWidth">0px</item>
+    <!-- Make icons appear inline with tab title -->
+    <item name="tabInlineLabel">true</item>
   </style>
 
   <style name="AppTheme.ShapeOverlay.Large" parent="">

--- a/resources/src/main/res/values/styles.xml
+++ b/resources/src/main/res/values/styles.xml
@@ -80,6 +80,7 @@
     <item name="tabIndicatorGravity">bottom</item>
     <item name="tabIndicatorHeight">3dp</item>
     <item name="tabMode">scrollable</item>
+    <item name="tabMaxWidth">0dp</item>
   </style>
 
   <style name="AppTheme.ShapeOverlay.Large" parent="">

--- a/resources/src/main/res/values/styles.xml
+++ b/resources/src/main/res/values/styles.xml
@@ -80,9 +80,9 @@
     <item name="tabIndicatorGravity">bottom</item>
     <item name="tabIndicatorHeight">3dp</item>
     <item name="tabMode">scrollable</item>
-    <!-- Increase tab width according to their title -->
+    <!-- Increase tab's width according to its title -->
     <item name="tabMaxWidth">0px</item>
-    <!-- Make icons appear inline with tab title -->
+    <!-- Make icons appear inline with tab's title -->
     <item name="tabInlineLabel">true</item>
   </style>
 


### PR DESCRIPTION
In the telegram group there was a [message](https://t.me/AndroidIDE_Discussions/63735/110749) mentioning editor tab names spanning multiple lines. This pull request aims to solve this and it also adds icons to those tabs depending on file types.

This PR is for now a draft, because I have some things to discuss.

1. Here is how tabs look with and without an icon. Even though `tabMaxWidth` is set to 0, therefore the `TextView` should just become bigger, for some reason with an icon enabled, the text is truncated. I assume that this depends on the inner implementation of `TabLayout.TabView`. Most of the methods there are private, therefore we can not really customize the implementation. I will try inserting a custom viewe for each tab, but am unsure if it will help. On the other hand, do we really need full size names? In most PC IDEs you will have the same picture of names on the tabs being truncated with `...` and after all there aren't that many cases of file names being too long to fit.

<details>
<summary> 🖼️ Screenshots of new tabs with and without icons </summary>

<img src="https://github.com/AndroidIDEOfficial/AndroidIDE/assets/71522503/feb4230d-9522-455f-8b55-d3ef9edbb280" width="48%"/>


<img src="https://github.com/AndroidIDEOfficial/AndroidIDE/assets/71522503/c6efe9e9-02ea-4f40-8a04-bcd52c1ab510" width="48%"/>

</details>

2. I changed the implementation of the `FileExtension` enum a bit. It now has more entries with `.extension` being an empty string. However, it is only used in two places now and `.extension` is never really used. Please, tell me if I have to separate this API into a separate function like `FileUtils.getIcon(File file)`.
