### PR TITLE
[FIX] Update links to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@
 <img src="https://img.shields.io/badge/License-GPLv3-blue.svg" alt="License"></p>
 
 <p align="center">
-  <a href="https://androidide.com/docs/">Explore the docs »</a> &nbsp; &nbsp;
-  <a href="https://androidide.com/blogs/">Read our blog »</a>
+  <a href="https://docs.androidide.com/">Explore the docs »</a> &nbsp; &nbsp;
 </p>
 
 <p align="center">

--- a/resources/src/main/res/values-ar-rSA/strings.xml
+++ b/resources/src/main/res/values-ar-rSA/strings.xml
@@ -444,7 +444,7 @@
   <string name="msg_files_being_saved">A file save operation is already in progress!</string>
   <string name="title_install_tools">SDK Installation</string>
   <string name="subtitle_install_tools">Install the development tools</string>
-  <string name="msg_install_tools">The development tools must be installed for the IDE to work. Clicking the done button will open terminal to install the tools. To install, follow the instructions <![CDATA[ <a href="https://androidide.com/blogs/getting-started/2023/03/15/getting-started-with-androidide/">here</a>.<br/><br/>Or read the <a href="https://androidide.com/docs/">documentation</a>]]>.</string>
+  <string name="msg_install_tools">The development tools must be installed for the IDE to work. Clicking the done button will open terminal to install the tools. To install, follow the instructions <![CDATA[ <a href="https://docs.androidide.com/tutorials/get-started.html">here</a>.<br/><br/>Or read the <a href="https://docs.androidide.com/">documentation</a>]]>.</string>
   <string name="greeting_title">Welcome</string>
   <string name="greeting_subtitle">Learn, build, launch. All on your Android.</string>
   <string name="title_grant">Grant</string>

--- a/resources/src/main/res/values-bn-rIN/strings.xml
+++ b/resources/src/main/res/values-bn-rIN/strings.xml
@@ -445,7 +445,7 @@
   <string name="msg_files_being_saved">একটি ফাইল save অপারেশন ইতিমধ্যেই চলছে!</string>
   <string name="title_install_tools">SDK ইনস্টলেশন</string>
   <string name="subtitle_install_tools">ডেভেলপমেন্ট টুলসগুলি ইনস্টল করুন</string>
-  <string name="msg_install_tools">IDE কাজ করার জন্য ডেভেলপমেন্ট টুলগুলি ইনস্টল করা আবশ্যক। সম্পন্ন বাটনে ক্লিক করলে টুলগুলি ইনস্টল করার জন্য টার্মিনাল খুলবে। ইনস্টল করতে, <![CDATA[ <a href="https://androidide.com/blogs/getting-started/2023/03/15/getting-started-with-androidide/"> এখানকার</a> নির্দেশাবলী অনুসরণ করুন।<br/><br/>অথবা <a href="https://androidide.com/docs/">ডকুমেন্টেশন</a>]]> পড়ুন।</string>
+  <string name="msg_install_tools">IDE কাজ করার জন্য ডেভেলপমেন্ট টুলগুলি ইনস্টল করা আবশ্যক। সম্পন্ন বাটনে ক্লিক করলে টুলগুলি ইনস্টল করার জন্য টার্মিনাল খুলবে। ইনস্টল করতে, <![CDATA[ <a href="https://docs.androidide.com/tutorials/get-started.html"> এখানকার</a> নির্দেশাবলী অনুসরণ করুন।<br/><br/>অথবা <a href="https://docs.androidide.com/">ডকুমেন্টেশন</a>]]> পড়ুন।</string>
   <string name="greeting_title">স্বাগতম</string>
   <string name="greeting_subtitle">শিখুন, তৈরি করুন, চালান। সব আপনার অ্যান্ড্রয়েডে।</string>
   <string name="title_grant">প্রদান করুন</string>

--- a/resources/src/main/res/values-de-rDE/strings.xml
+++ b/resources/src/main/res/values-de-rDE/strings.xml
@@ -444,7 +444,7 @@
   <string name="msg_files_being_saved">Ein Speichervorgang wird bereits ausgeführt!</string>
   <string name="title_install_tools">SDK-Installation</string>
   <string name="subtitle_install_tools">Entwicklungstools installieren</string>
-  <string name="msg_install_tools">Die Entwicklungstools müssen installiert werden, damit die IDE funktioniert. Durch Klicken auf den Button wird das Terminal geöffnet, um die Tools zu installieren. Um diese zu installieren, folgen Sie den Anweisungen <![CDATA[ <a href="https://androidide.com/blogs/getting-started/2023/03/15/getting-started-with-androidide/">hier</a>.<br/><br/>Oder lesen Sie die <a href="https://androidide.com/docs/">Dokumentation</a>]]>.</string>
+  <string name="msg_install_tools">Die Entwicklungstools müssen installiert werden, damit die IDE funktioniert. Durch Klicken auf den Button wird das Terminal geöffnet, um die Tools zu installieren. Um diese zu installieren, folgen Sie den Anweisungen <![CDATA[ <a href="https://docs.androidide.com/tutorials/get-started.html">hier</a>.<br/><br/>Oder lesen Sie die <a href="https://docs.androidide.com/">Dokumentation</a>]]>.</string>
   <string name="greeting_title">Willkommen</string>
   <string name="greeting_subtitle">Lerne, Erstelle, Veröffentliche. Alles auf Ihrem Android.</string>
   <string name="title_grant">Gewähren</string>

--- a/resources/src/main/res/values-es-rES/strings.xml
+++ b/resources/src/main/res/values-es-rES/strings.xml
@@ -444,7 +444,7 @@
   <string name="msg_files_being_saved">A file save operation is already in progress!</string>
   <string name="title_install_tools">SDK Installation</string>
   <string name="subtitle_install_tools">Install the development tools</string>
-  <string name="msg_install_tools">The development tools must be installed for the IDE to work. Clicking the done button will open terminal to install the tools. To install, follow the instructions <![CDATA[ <a href="https://androidide.com/blogs/getting-started/2023/03/15/getting-started-with-androidide/">here</a>.<br/><br/>Or read the <a href="https://androidide.com/docs/">documentation</a>]]>.</string>
+  <string name="msg_install_tools">The development tools must be installed for the IDE to work. Clicking the done button will open terminal to install the tools. To install, follow the instructions <![CDATA[ <a href="https://docs.androidide.com/tutorials/get-started.html">here</a>.<br/><br/>Or read the <a href="https://docs.androidide.com/">documentation</a>]]>.</string>
   <string name="greeting_title">Welcome</string>
   <string name="greeting_subtitle">Learn, build, launch. All on your Android.</string>
   <string name="title_grant">Grant</string>

--- a/resources/src/main/res/values-fr-rFR/strings.xml
+++ b/resources/src/main/res/values-fr-rFR/strings.xml
@@ -445,7 +445,7 @@ Dernier projet ouvert : \n%s</string>
   <string name="msg_files_being_saved">A file save operation is already in progress!</string>
   <string name="title_install_tools">SDK Installation</string>
   <string name="subtitle_install_tools">Install the development tools</string>
-  <string name="msg_install_tools">The development tools must be installed for the IDE to work. Clicking the done button will open terminal to install the tools. To install, follow the instructions <![CDATA[ <a href="https://androidide.com/blogs/getting-started/2023/03/15/getting-started-with-androidide/">here</a>.<br/><br/>Or read the <a href="https://androidide.com/docs/">documentation</a>]]>.</string>
+  <string name="msg_install_tools">The development tools must be installed for the IDE to work. Clicking the done button will open terminal to install the tools. To install, follow the instructions <![CDATA[ <a href="https://docs.androidide.com/tutorials/get-started.html">here</a>.<br/><br/>Or read the <a href="https://docs.androidide.com/">documentation</a>]]>.</string>
   <string name="greeting_title">Welcome</string>
   <string name="greeting_subtitle">Learn, build, launch. All on your Android.</string>
   <string name="title_grant">Grant</string>

--- a/resources/src/main/res/values-hi-rIN/strings.xml
+++ b/resources/src/main/res/values-hi-rIN/strings.xml
@@ -444,7 +444,7 @@
   <string name="msg_files_being_saved">फ़ाइल सहेजने का कार्य पहले से ही प्रगति पर है!</string>
   <string name="title_install_tools">SDK इंस्टालेशन</string>
   <string name="subtitle_install_tools">विकास उपकरण इनस्टॉल करें</string>
-  <string name="msg_install_tools">आईडीई के काम करने के लिए विकास उपकरण इनस्टॉल होने चाहिए। डन बटन पर क्लिक करने से उपकरण इनस्टॉल करने के लिए टर्मिनल खुल जाएगा। इंस्टॉल करने के लिए, <![CDATA[ <a href="https://androidide.com/blogs/getting-started/2023/03/15/getting-started-with-androidide/">इन</a > निर्देशों का पालन करें । <br/><br/>या <a href="https://androidide.com/docs/">दस्तावेज़ीकरण</a>]]> पढ़ें।</string>
+  <string name="msg_install_tools">आईडीई के काम करने के लिए विकास उपकरण इनस्टॉल होने चाहिए। डन बटन पर क्लिक करने से उपकरण इनस्टॉल करने के लिए टर्मिनल खुल जाएगा। इंस्टॉल करने के लिए, <![CDATA[ <a href="https://docs.androidide.com/tutorials/get-started.html">इन</a > निर्देशों का पालन करें । <br/><br/>या <a href="https://docs.androidide.com/">दस्तावेज़ीकरण</a>]]> पढ़ें।</string>
   <string name="greeting_title">स्वागत है</string>
   <string name="greeting_subtitle">सीखें, निर्माण करें, लॉन्च करें। सभी आपके Android पर.</string>
   <string name="title_grant">अनुमति दें</string>

--- a/resources/src/main/res/values-in-rID/strings.xml
+++ b/resources/src/main/res/values-in-rID/strings.xml
@@ -444,7 +444,7 @@
   <string name="msg_files_being_saved">Operasi penyimpanan file sedang berlangsung!</string>
   <string name="title_install_tools">Instalasi SDK</string>
   <string name="subtitle_install_tools">Instal alat pengembangan</string>
-  <string name="msg_install_tools">Alat pengembangan harus diinstal agar IDE dapat berfungsi. Mengklik tombol selesai akan membuka terminal untuk menginstal alat. Untuk menginstal, ikuti petunjuk <![CDATA[ <a href="https://androidide.com/blogs/getting-started/2023/03/15/getting-started-with-androidide/">di sini</a>.<br/><br/>Atau baca <a href="https://androidide.com/docs/">dokumentasi</a>]]>.</string>
+  <string name="msg_install_tools">Alat pengembangan harus diinstal agar IDE dapat berfungsi. Mengklik tombol selesai akan membuka terminal untuk menginstal alat. Untuk menginstal, ikuti petunjuk <![CDATA[ <a href="https://docs.androidide.com/tutorials/get-started.html">di sini</a>.<br/><br/>Atau baca <a href="https://docs.androidide.com/">dokumentasi</a>]]>.</string>
   <string name="greeting_title">Selamat datang</string>
   <string name="greeting_subtitle">Pelajari, bangun, luncurkan. Semua di Android Anda.</string>
   <string name="title_grant">Izinkan</string>

--- a/resources/src/main/res/values-pt-rBR/strings.xml
+++ b/resources/src/main/res/values-pt-rBR/strings.xml
@@ -444,7 +444,7 @@
   <string name="msg_files_being_saved">Uma operação de salvamento de arquivo já está em andamento!</string>
   <string name="title_install_tools">Instalação do SDK</string>
   <string name="subtitle_install_tools">Instalar as ferramentas de desenvolvimento</string>
-  <string name="msg_install_tools">As ferramentas de desenvolvimento devem ser instaladas para que o IDE funcione. Ao clicar no botão concluído, o terminal será aberto para instalar as ferramentas. Para instalar, siga as instruções <![CDATA[ <a href="https://androidide.com/blogs/getting-started/2023/03/15/getting-started-with-androidide/">aqui</a>.<br/><br/>Ou leia a documentação <a href="https://androidide.com/docs/"></a>]]>.</string>
+  <string name="msg_install_tools">As ferramentas de desenvolvimento devem ser instaladas para que o IDE funcione. Ao clicar no botão concluído, o terminal será aberto para instalar as ferramentas. Para instalar, siga as instruções <![CDATA[ <a href="https://docs.androidide.com/tutorials/get-started.html">aqui</a>.<br/><br/>Ou leia a documentação <a href="https://docs.androidide.com/"></a>]]>.</string>
   <string name="greeting_title">Bem-vindo</string>
   <string name="greeting_subtitle">Aprenda, construa, lançe. Tudo no seu Android.</string>
   <string name="title_grant">Conceder</string>

--- a/resources/src/main/res/values-ro-rRO/strings.xml
+++ b/resources/src/main/res/values-ro-rRO/strings.xml
@@ -444,7 +444,7 @@
   <string name="msg_files_being_saved">A file save operation is already in progress!</string>
   <string name="title_install_tools">SDK Installation</string>
   <string name="subtitle_install_tools">Install the development tools</string>
-  <string name="msg_install_tools">The development tools must be installed for the IDE to work. Clicking the done button will open terminal to install the tools. To install, follow the instructions <![CDATA[ <a href="https://androidide.com/blogs/getting-started/2023/03/15/getting-started-with-androidide/">here</a>.<br/><br/>Or read the <a href="https://androidide.com/docs/">documentation</a>]]>.</string>
+  <string name="msg_install_tools">The development tools must be installed for the IDE to work. Clicking the done button will open terminal to install the tools. To install, follow the instructions <![CDATA[ <a href="https://docs.androidide.com/tutorials/get-started.html">here</a>.<br/><br/>Or read the <a href="https://docs.androidide.com/">documentation</a>]]>.</string>
   <string name="greeting_title">Welcome</string>
   <string name="greeting_subtitle">Learn, build, launch. All on your Android.</string>
   <string name="title_grant">Grant</string>

--- a/resources/src/main/res/values-ru-rRU/strings.xml
+++ b/resources/src/main/res/values-ru-rRU/strings.xml
@@ -445,7 +445,7 @@
   <string name="msg_files_being_saved">Сохранение файла уже в процессе!</string>
   <string name="title_install_tools">Установка SDK</string>
   <string name="subtitle_install_tools">Установка инструментов разработки</string>
-  <string name="msg_install_tools">Для работы IDE требуется установить инструменты разработки (SDK). Кнопка ниже запустит терминал для дальнейшей установки SDK. Следуйте <![CDATA[ <a href="https://androidide.com/blogs/getting-started/2023/03/15/getting-started-with-androidide/">инструкциям</a>.<br/><br/>Вы также можете ознакомиться с <a href="https://androidide.com/docs/">документацией</a>]]>.</string>
+  <string name="msg_install_tools">Для работы IDE требуется установить инструменты разработки (SDK). Кнопка ниже запустит терминал для дальнейшей установки SDK. Следуйте <![CDATA[ <a href="https://docs.androidide.com/tutorials/get-started.html">инструкциям</a>.<br/><br/>Вы также можете ознакомиться с <a href="https://docs.androidide.com/">документацией</a>]]>.</string>
   <string name="greeting_title">Добро пожаловать!</string>
   <string name="greeting_subtitle">Изучайте, создавайте и запускайте. Полноценное IDE на вашем Android!</string>
   <string name="title_grant">Предоставить</string>

--- a/resources/src/main/res/values-tr-rTR/strings.xml
+++ b/resources/src/main/res/values-tr-rTR/strings.xml
@@ -444,7 +444,7 @@
   <string name="msg_files_being_saved">Bir dosya kaydetme işlemi zaten devam ediyor!</string>
   <string name="title_install_tools">SDK kurulumu</string>
   <string name="subtitle_install_tools">Geliştirme araçlarını yükle</string>
-  <string name="msg_install_tools">Geliştirici araçları IDE\'nin çalışması için yüklenmeli. Tamam butonuna tıklamak kurulum terminalini açacaktır. Yüklemek için, adımları takip edin <![CDATA[ <a href="https://androidide.com/blogs/getting-started/2023/03/15/getting-started-with-androidide/">Buradan</a>. <br/><br/> Veya <a href="https://androidide.com/docs/">Dokümanları okuyun</a>]]>.</string>
+  <string name="msg_install_tools">Geliştirici araçları IDE\'nin çalışması için yüklenmeli. Tamam butonuna tıklamak kurulum terminalini açacaktır. Yüklemek için, adımları takip edin <![CDATA[ <a href="https://docs.androidide.com/tutorials/get-started.html">Buradan</a>. <br/><br/> Veya <a href="https://docs.androidide.com/">Dokümanları okuyun</a>]]>.</string>
   <string name="greeting_title">Hoş geldiniz</string>
   <string name="greeting_subtitle">Öğren, inşa et, çalıştır. Hepsi Android\'inde.</string>
   <string name="title_grant">İzin ver</string>

--- a/resources/src/main/res/values-zh-rCN/strings.xml
+++ b/resources/src/main/res/values-zh-rCN/strings.xml
@@ -444,7 +444,7 @@
   <string name="msg_files_being_saved">文件保存操作已在进行中！</string>
   <string name="title_install_tools">SDK 安装</string>
   <string name="subtitle_install_tools">安装开发工具</string>
-  <string name="msg_install_tools">必须安装开发工具才能使 IDE 工作，单击完成按钮将打开终端来安装工具。若要安装，请按照<![CDATA[ <a href="https://androidide.com/blogs/getting-started/2023/03/15/getting-started-with-androidide/">此处</a>的说明进行操作。<br/><br/>或者阅读<a href="https://androidide.com/docs/">文档</a>]]>。</string>
+  <string name="msg_install_tools">必须安装开发工具才能使 IDE 工作，单击完成按钮将打开终端来安装工具。若要安装，请按照<![CDATA[ <a href="https://docs.androidide.com/tutorials/get-started.html">此处</a>的说明进行操作。<br/><br/>或者阅读<a href="https://docs.androidide.com/">文档</a>]]>。</string>
   <string name="greeting_title">欢迎</string>
   <string name="greeting_subtitle">学习、构建、启动，一切尽在您的 Android 设备上。</string>
   <string name="title_grant">授权</string>

--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -521,7 +521,7 @@
   <string name="msg_files_being_saved">A file save operation is already in progress!</string>
   <string name="title_install_tools">SDK Installation</string>
   <string name="subtitle_install_tools">Install the development tools</string>
-  <string name="msg_install_tools">The development tools must be installed for the IDE to work. Clicking the done button will open terminal to install the tools. To install, follow the instructions <![CDATA[ <a href="https://androidide.com/blogs/getting-started/2023/03/15/getting-started-with-androidide/">here</a>.<br/><br/>Or read the <a href="https://androidide.com/docs/">documentation</a>]]>.</string>
+  <string name="msg_install_tools">The development tools must be installed for the IDE to work. Clicking the done button will open terminal to install the tools. To install, follow the instructions <![CDATA[ <a href="https://docs.androidide.com/tutorials/get-started.html">here</a>.<br/><br/>Or read the <a href="https://docs.androidide.com/">documentation</a>]]>.</string>
   <string name="greeting_title">Welcome</string>
   <string name="greeting_subtitle">Learn, build, launch. All on your Android.</string>
   <string name="title_grant">Grant</string>


### PR DESCRIPTION
Updated links to the documentation and the "Getting started" tutorial. Mention of the AndroidIDE blog is removed.