### PR TITLE
fix: ignore soft input changes if EditorActivity is being destroyed

### DIFF
--- a/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
+++ b/app/src/main/java/com/itsaky/androidide/activities/editor/BaseEditorActivity.kt
@@ -589,8 +589,10 @@ abstract class BaseEditorActivity :
   }
 
   private fun onSoftInputChanged() {
-    invalidateOptionsMenu()
-    binding.bottomSheet.onSoftInputChanged()
+    if (!isDestroying) {
+      invalidateOptionsMenu()
+      binding.bottomSheet.onSoftInputChanged()
+    }
   }
 
   private fun showNeedHelpDialog() {


### PR DESCRIPTION
Ignoring soft input changes if activity is being destroyed may resolve this issue: #1717 